### PR TITLE
Do not rely on parse_document() dict item order in parse_rules().

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,5 +193,6 @@ deployment-test: env dist/orm-${ORM_TAG}.tar.gz start-orm-deployment
 release-test:
 	make clean
 	make lint
+	make black
 	make test
 	make deployment-test

--- a/orm/parser.py
+++ b/orm/parser.py
@@ -313,7 +313,7 @@ def parse_rules(yml_files, defaults=None):
         yml_docs = parse_yaml_file(yml_file)
         for doc in yml_docs:
             parsed_doc = parse_document(doc)
-            for domain, rules in parsed_doc["rules"].items():
+            for domain, rules in sorted(parsed_doc["rules"].items()):
                 merged_documents["rules"].setdefault(domain, [])
                 for rule in rules:
                     rule_copy = copy.deepcopy(rule)


### PR DESCRIPTION
 Sort explicitly.

This makes "make test" deterministic for python 3.5.