### PR TITLE
Updates to logging

### DIFF
--- a/orm-rules-tests/49-haproxy.conf
+++ b/orm-rules-tests/49-haproxy.conf
@@ -1,0 +1,13 @@
+$AddUnixListenSocket /dev/rsyslog
+$SystemLogRateLimitInterval 0
+
+$umask 0000
+$FileCreateMode 0644
+
+$template haproxy,"%msg:2:$%\n"
+
+# Send HAProxy messages to a dedicated logfile
+if $programname startswith 'haproxy' then {
+    local2.* /var/log/haproxy.log;haproxy
+    stop
+}

--- a/orm-rules-tests/start_echo_servers.sh
+++ b/orm-rules-tests/start_echo_servers.sh
@@ -2,9 +2,12 @@
 set -xe
 
 lxc file push orm-rules-tests/echo_server.py orm/root/
+lxc file push orm-rules-tests/49-haproxy.conf orm/etc/rsyslog.d/
 lxc file push \
     orm-rules-tests/echo_server@.service \
     orm/etc/systemd/system/echo_server@.service
+lxc exec orm systemctl restart rsyslog
+lxc exec orm systemctl restart haproxy
 lxc exec orm systemctl daemon-reload
 lxc exec orm systemctl restart echo_server@7357
 lxc exec orm systemctl restart echo_server@7358

--- a/orm/templates/haproxy.cfg.j2
+++ b/orm/templates/haproxy.cfg.j2
@@ -76,7 +76,7 @@ listen orm_external
     capture request header User-Agent            len 128
     capture request header Host                  len 64
     capture request header X-Forwarded-For       len 64
-    log-format '{"time":%Ts%ms,"status":%ST,"http_request":"%r","remote_addr":"%ci","bytes":%B,"upstream_addr":"%si","backend_name":"%b","retries":%rc,"bytes_uploaded":%U,"connect":%Tc,"service":%Tt,"termination_state":"%ts","headers":"%hr","request_id":"%ID"}'
+    log-format '{"actconn":%ac,"feconn":%fc,"beconn":%bc,"srv_conn":%sc,"srv_queue":%sq,"backend_queue":%bq,"backend_name":"%b","bytes":%B,"bytes_uploaded":%U,"connect":%Tc,"headers":"%hr","http_request":"%r","queued":%Tw,"remote_addr":"%ci","request_id":"%ID","retries":%rc,"service":%Tt,"status":"%ST","termination_state":"%ts","time":%Ts%ms,"time_active":%Ta,"time_handshake":%Th,"time_idle":%Ti,"time_queue":%Tw,"time_request":%TR,"time_response":%Tr,"time_session":%Tt,"time_srv_connect":%Tc,"time_data":%Td,"upstream_addr":"%si"}'
     log global
 
     option http-keep-alive
@@ -110,7 +110,7 @@ frontend orm_loopback
     capture request header X-Forwarded-For       len 64
     capture request header X-Request-ID          len 64
 {% raw %}
-    log-format '{"time":%Ts%ms,"status":%ST,"http_request":"%r","remote_addr":"%ci","bytes":%B,"upstream_addr":"%si","backend_name":"%b","retries":%rc,"bytes_uploaded":%U,"connect":%Tc,"service":%Tt,"termination_state":"%ts","headers":"{%[capture.req.hdr(0)]|%[capture.req.hdr(1)]|%[capture.req.hdr(2)]|%[capture.req.hdr(3)]}","request_id":"%[capture.req.hdr(4)]"}'
+    log-format '{"actconn":%ac,"feconn":%fc,"beconn":%bc,"srv_conn":%sc,"srv_queue":%sq,"backend_queue":%bq,"backend_name":"%b","backend_name":"%b","bytes":%B,"bytes_uploaded":%U,"time":%Ts%ms,"status":%ST,"http_request":"%r","queued":%Tw,"remote_addr":"%ci","retries":%rc,"upstream_addr":"%si","connect":%Tc,"service":%Tt,"termination_state":"%ts","time_active":%Ta,"time_handshake":%Th,"time_idle":%Ti,"time_queue":%Tw,"time_request":%TR,"time_response":%Tr,"time_session":%Tt,"time_srv_connect":%Tc,"time_data":%Td,"headers":"{%[capture.req.hdr(0)]|%[capture.req.hdr(1)]|%[capture.req.hdr(2)]|%[capture.req.hdr(3)]}","request_id":"%[capture.req.hdr(4)]"}'
 {% endraw %}
     log global
 

--- a/orm/templates/haproxy.cfg.j2
+++ b/orm/templates/haproxy.cfg.j2
@@ -1,5 +1,5 @@
 global
-    log /dev/rsyslog local2
+    log /dev/rsyslog len 4096 local2
     user {{ user }}
     group {{ group }}
     stats socket /var/run/haproxy.sock mode 0660 level admin user {{ control_user }} group {{ control_group }}


### PR DESCRIPTION
- Configure rsyslog for haproxy.log in tests
- Adding queue and time metrics to haproxy log-format
- Raise HAProxy log-format truncating from 1024 (default) to 4096