### PR TITLE
Modified/corrected changelog for new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2019-05-28
+
+### Changed
+- Extended log format to include multiple timing fields.
+
 ## [1.1.0] - 2019-05-09
 
 ### Added
@@ -13,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Port echo_server.py used in deployment tests to python3.
-- Extended log format to include multiple timing fields.
 
 ## [1.0.0] - 2019-03-15
 


### PR DESCRIPTION
New release to include the changes to log formats that were incorrectly included in changelog for 1.1.0.