### PR TITLE
Fix field type in log_format for haproxy orm_external.

### DIFF
--- a/orm/templates/haproxy.cfg.j2
+++ b/orm/templates/haproxy.cfg.j2
@@ -76,7 +76,7 @@ listen orm_external
     capture request header User-Agent            len 128
     capture request header Host                  len 64
     capture request header X-Forwarded-For       len 64
-    log-format '{"actconn":%ac,"feconn":%fc,"beconn":%bc,"srv_conn":%sc,"srv_queue":%sq,"backend_queue":%bq,"backend_name":"%b","bytes":%B,"bytes_uploaded":%U,"connect":%Tc,"headers":"%hr","http_request":"%r","queued":%Tw,"remote_addr":"%ci","request_id":"%ID","retries":%rc,"service":%Tt,"status":"%ST","termination_state":"%ts","time":%Ts%ms,"time_active":%Ta,"time_handshake":%Th,"time_idle":%Ti,"time_queue":%Tw,"time_request":%TR,"time_response":%Tr,"time_session":%Tt,"time_srv_connect":%Tc,"time_data":%Td,"upstream_addr":"%si"}'
+    log-format '{"actconn":%ac,"feconn":%fc,"beconn":%bc,"srv_conn":%sc,"srv_queue":%sq,"backend_queue":%bq,"backend_name":"%b","bytes":%B,"bytes_uploaded":%U,"connect":%Tc,"headers":"%hr","http_request":"%r","queued":%Tw,"remote_addr":"%ci","request_id":"%ID","retries":%rc,"service":%Tt,"status":%ST,"termination_state":"%ts","time":%Ts%ms,"time_active":%Ta,"time_handshake":%Th,"time_idle":%Ti,"time_queue":%Tw,"time_request":%TR,"time_response":%Tr,"time_session":%Tt,"time_srv_connect":%Tc,"time_data":%Td,"upstream_addr":"%si"}'
     log global
 
     option http-keep-alive


### PR DESCRIPTION
In the haproxy log_format for orm_external listener the field `status` accidentally got a quoted value. 

This commit fixes that, by removing quotes again.