### PR TITLE
Extend collision check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,10 +180,10 @@ deployment-test: env dist/orm-${ORM_TAG}.tar.gz start-orm-deployment
 	@echo "Testing rules with globals actions"
 	orm-rules-tests/start_echo_servers.sh
 	$(ENV_PREP_COMMAND) && \
-    orm \
+		orm \
 			-r 'orm-rules-tests/globals-test/rules/**/*.yml' \
 			-G 'orm-rules-tests/globals-test/globals.yml' \
-				--cache-path 'orm-rules-tests/globals-test/cache.pkl' \
+			--cache-path 'orm-rules-tests/globals-test/cache.pkl' \
 			-o out
 	lxd/update-orm-config.sh out
 	orm-rules-tests/wait_for_orm.sh

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ORM manages routing configuration based on rules defined in yaml format. It uses
 ```yaml
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Rule for requests to www.example.com/example

--- a/docs/rules-cookbook.md
+++ b/docs/rules-cookbook.md
@@ -93,34 +93,31 @@ Match paths that either match one of a list of exact strings or a regex:
             - '/the/last/exact/path/'
 ```
 
-### 1.2  Query parameter matching
+### 1.2  Query string matching
 
-Match a request based on a specific value for a parameter:
+Match a request based on a specific query string value:
 
 ```
   matches:
     any:
       - query:
-          parameter: my_parameter
           exact:
-            - required_value
+            - 'param=value'
 ```
 
-Match requests on multiple parameters, case-insensitive on the second parameter which can begin with either `foo` or `bar`:
+Match requests on multiple query strings, case-insensitive on the second matching where the query string can begin with either `param=foo` or `other_param=foo`:
 
 ```
   matches:
-    all:
+    any:
       - query:
-          parameter: my_parameter
           exact:
-            - required_value
+            - 'param=value'
       - query:
-          parameter: other_parameter
-          ignore_case: true
           begins_with:
-             - foo
-             - bar
+            - 'param=foo'
+            - 'other_param=bar'
+          ignore_case: true
 ```
 
 ### 1.3  Negative matching
@@ -453,15 +450,14 @@ rules:
 
 ```
 rules:
-  - description: Rule to route requests with a specific query parameter to a separate backend
+  - description: Rule to route requests with a specific query string to a separate backend
     domains:
       - www.domain.example
     matches:
       all:
         - query:
-            parameter: special
             exact:
-              - True
+              - 'special=True'
     actions:
       backend:
         origin: https://special.origin.example
@@ -470,14 +466,15 @@ rules:
             field: 'Host'
             value: 'special.origin.example'
 
-  - description: Rule to route requests without a specific query parameter to another backend
+  - description: Rule to route requests without a specific query string to another backend
     domains:
       - www.domain.example
     matches:
       all:
         - query:
-            parameter: special
-            exist: False
+            not: True
+            exact:
+              - 'special=True'
     actions:
       backend:
         origin: https://other.origin.example

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -21,7 +21,7 @@ To route requests to `www.example.com` with a path beginning with `/example` (e.
 ```yaml
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Rule for requests to www.example.com/example

--- a/docs/syntax_reference.md
+++ b/docs/syntax_reference.md
@@ -134,10 +134,8 @@ To ignore case (i.e. do case insensitive matching), set `ignore_case: True`.
 
 | key         | required | type                        |
 |-------------|:--------:|-----------------------------|
-| parameter   | ✓        | [uri-query](#uri-query)     |
 | ignore_case |          | boolean (default: false)    |
 | not         |          | boolean (default: false)    |
-| exist       | *        | [exist](#exist)             |
 | begins_with | *        | [begins_with](#begins-with) |
 | ends_with   | *        | [ends_with](#ends-with)     |
 | contains    | *        | [contains](#contains)       |
@@ -185,12 +183,6 @@ Equivalent to the [orm-regex](#orm-regex): `string`
 *array of orm_regex*
 
 Satisfied when the input is matched against any of the supplied regular expressions. See [orm-regex](#orm-regex) for reference.
-
-### `exist`
-
-*boolean*
-
-Satisfied when the input exists.
 
 ## Actions
 

--- a/docs/syntax_reference.md
+++ b/docs/syntax_reference.md
@@ -4,10 +4,10 @@ There are two types of configuration files for ORM, [globals](#orm-globals) and 
 
 *integer*
 
-The ORM schema version used in this YAML document. Currently `1`. The globals schema is specified in [globals-1.json](../orm/schemas/globals-1.json) and the rules schema is specified in [rules-1.json](../orm/schemas/rules-1.json). For a complete reference of all ORM schema versions, refer to the ORM project's [schemata](../orm/schemas/) folder.
+The ORM schema version used in this YAML document. The globals schema is specified in [globals-1.json](../orm/schemas/globals-1.json) (currently `1`) and the rules schema is specified in [rules-2.json](../orm/schemas/rules-2.json) (currently `2`). For a complete reference of all ORM schema versions, refer to the ORM project's [schemata](../orm/schemas/) folder.
  For all supported versions and their schemata, see [schemas.py](../orm/schemas.py).
 
-Values: `1`
+Values: `1`, `2`
 
 Default: `None`
 

--- a/example/rules/team-a/secret-service.yml
+++ b/example/rules/team-a/secret-service.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Team A secret service backend

--- a/example/rules/team-a/service.yml
+++ b/example/rules/team-a/service.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 # This file contains two ORM rules
 rules:

--- a/example/rules/team-b/service.yml
+++ b/example/rules/team-b/service.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Team B service backend

--- a/example/rules/team-c/service.yml
+++ b/example/rules/team-c/service.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Team C service backend

--- a/orm-rules-tests/globals-test/rules/orm_status.yml
+++ b/orm-rules-tests/globals-test/rules/orm_status.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Rule for verifying ORM status

--- a/orm-rules-tests/globals-test/rules/test_globals.yml
+++ b/orm-rules-tests/globals-test/rules/test_globals.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Default HTTPS redir'
@@ -27,7 +27,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Global action https_redirection false'
@@ -55,7 +55,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Global actions (req_path, headers)'
@@ -86,7 +86,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Global actions override-able'

--- a/orm-rules-tests/rules-test/rules/orm_status.yml
+++ b/orm-rules-tests/rules-test/rules/orm_status.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Rule for verifying ORM status

--- a/orm-rules-tests/rules-test/rules/test_backend.yml
+++ b/orm-rules-tests/rules-test/rules/test_backend.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test backend origin

--- a/orm-rules-tests/rules-test/rules/test_backend_maxconn_maxqueue.yml
+++ b/orm-rules-tests/rules-test/rules/test_backend_maxconn_maxqueue.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test backend with max_connections and max_queued_connections

--- a/orm-rules-tests/rules-test/rules/test_domain_default.yml
+++ b/orm-rules-tests/rules-test/rules/test_domain_default.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test domain_default

--- a/orm-rules-tests/rules-test/rules/test_header_northbound.yml
+++ b/orm-rules-tests/rules-test/rules/test_header_northbound.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test header_northbound set'
@@ -59,7 +59,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test header_northbound add'
@@ -98,7 +98,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test header_northbound remove'

--- a/orm-rules-tests/rules-test/rules/test_header_southbound.yml
+++ b/orm-rules-tests/rules-test/rules/test_header_southbound.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test header_southbound set'
@@ -57,7 +57,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test header_southbound add'
@@ -93,7 +93,7 @@ tests:
         - regex: 'header=BEST-HEADER: BEST-VALUE\r\n'
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test header_southbound remove'

--- a/orm-rules-tests/rules-test/rules/test_https_redirection.yml
+++ b/orm-rules-tests/rules-test/rules/test_https_redirection.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Explicit HTTPS redir'

--- a/orm-rules-tests/rules-test/rules/test_ignore_case.yml
+++ b/orm-rules-tests/rules-test/rules/test_ignore_case.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test ignore_case'
@@ -25,7 +25,7 @@ tests:
         - regex: 'Catched by the ignore_case case just in case, in case you wondered\.'
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test ignore_case default off'

--- a/orm-rules-tests/rules-test/rules/test_match_advanced.yml
+++ b/orm-rules-tests/rules-test/rules/test_match_advanced.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test advanced match not'

--- a/orm-rules-tests/rules-test/rules/test_match_advanced.yml
+++ b/orm-rules-tests/rules-test/rules/test_match_advanced.yml
@@ -18,9 +18,9 @@ rules:
             contains:
               - 'wrongo'
         - query:
-            parameter: bad_param
             not: True
-            exist: True
+            exact:
+              - 'bad_param=present'
       any:
         - paths:
             contains:
@@ -28,10 +28,8 @@ rules:
               - 'or_have_this'
         - query:
             not: True
-            parameter: color
-            contains:
-              - red
-              - blue
+            exact:
+              - 'color=red'
     actions:
       synthetic_response: 'advanced_match'
 
@@ -111,7 +109,7 @@ tests:
   # Not satisfying any of the match any
   - name: 'Test advanced match not 5 wrong'
     request:
-      url: 'https://test/advanced_match/?color=blue&color=red'
+      url: 'https://test/advanced_match/?color=red'
     expect:  # domain_default backend
       status: 200
       body:

--- a/orm-rules-tests/rules-test/rules/test_match_all.yml
+++ b/orm-rules-tests/rules-test/rules/test_match_all.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test match all

--- a/orm-rules-tests/rules-test/rules/test_match_all.yml
+++ b/orm-rules-tests/rules-test/rules/test_match_all.yml
@@ -12,9 +12,8 @@ rules:
             exact:
               - '/all/foo'
         - query:
-            parameter: 'match'
             exact:
-              - 'me'
+              - 'match=me'
     actions:
       synthetic_response: 'match_all'
 

--- a/orm-rules-tests/rules-test/rules/test_match_any.yml
+++ b/orm-rules-tests/rules-test/rules/test_match_any.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test match any

--- a/orm-rules-tests/rules-test/rules/test_match_not.yml
+++ b/orm-rules-tests/rules-test/rules/test_match_not.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test simple match not'

--- a/orm-rules-tests/rules-test/rules/test_match_paths.yml
+++ b/orm-rules-tests/rules-test/rules/test_match_paths.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test match paths begins_with
@@ -41,7 +41,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test match paths ends_with
@@ -80,7 +80,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test match paths contains
@@ -119,7 +119,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test match paths exact
@@ -152,7 +152,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test match paths regex

--- a/orm-rules-tests/rules-test/rules/test_match_query.yml
+++ b/orm-rules-tests/rules-test/rules/test_match_query.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test match query begins_with
@@ -42,7 +42,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test match query ends_with
@@ -84,7 +84,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test match query contains
@@ -142,7 +142,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test match query exact
@@ -176,7 +176,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test match query regex

--- a/orm-rules-tests/rules-test/rules/test_match_query.yml
+++ b/orm-rules-tests/rules-test/rules/test_match_query.yml
@@ -5,23 +5,22 @@ schema_version: 1
 rules:
   - description: Test match query begins_with
     domains:
-      - test
+      - test-query
     matches:
       all:
         - paths:
             exact:
               - '/query/begins_with'
         - query:
-            parameter: param
             begins_with:
-              - 'this'
+              - 'param=value'
     actions:
       synthetic_response: 'match_query_begins_with'
 
 tests:
   - name: Test match query begins_with exact
     request:
-      url: 'https://test/query/begins_with?param=this'
+      url: 'https://test-query/query/begins_with?param=value'
     expect:
       status: 200
       body:
@@ -29,7 +28,7 @@ tests:
 
   - name: Test match query begins_with
     request:
-      url: 'https://test/query/begins_with?param=this_is_right&yeah=boi&oo=yo#yes'
+      url: 'https://test-query/query/begins_with?param=value&param2=othervalue'
     expect:
       status: 200
       body:
@@ -37,11 +36,9 @@ tests:
 
   - name: Test match query begins_with wrong
     request:
-      url: 'https://test/query/begins_with?param=begins_almost_with_thi_s&this=yeah'
-    expect:  # domain_default backend
-      status: 200
-      body:
-        - regex: 'name=1337'
+      url: 'https://test-query/query/begins_with?does_not=begin_with&param=value'
+    expect:  # no configured backend
+      status: 500
 
 ---
 
@@ -50,23 +47,22 @@ schema_version: 1
 rules:
   - description: Test match query ends_with
     domains:
-      - test
+      - test-query
     matches:
       all:
         - paths:
             exact:
               - '/query/ends_with'
         - query:
-            parameter: param
             ends_with:
-              - 'this'
+              - 'param=value'
     actions:
       synthetic_response: 'match_query_ends_with'
 
 tests:
   - name: Test match query ends_with exact
     request:
-      url: 'https://test/query/ends_with?param=this'
+      url: 'https://test-query/query/ends_with?param=value'
     expect:
       status: 200
       body:
@@ -74,7 +70,7 @@ tests:
 
   - name: Test match query ends_with
     request:
-      url: 'https://test/query/ends_with?param=the_beginning_ends_with_this&yeah=boi&oo=yo#yes'
+      url: 'https://test-query/query/ends_with?the=famous&param=value'
     expect:
       status: 200
       body:
@@ -82,11 +78,9 @@ tests:
 
   - name: Test match query ends_with wrong
     request:
-      url: 'https://test/query/ends_with?param=almost_ends_with&this=yo'
-    expect:  # domain_default backend
-      status: 200
-      body:
-        - regex: 'name=1337'
+      url: 'https://test-query/query/ends_with?param=value&is_not=the_end'
+    expect:  # no configured backend
+      status: 500
 
 ---
 
@@ -95,23 +89,22 @@ schema_version: 1
 rules:
   - description: Test match query contains
     domains:
-      - test
+      - test-query
     matches:
       all:
         - paths:
             exact:
               - '/query/contains'
         - query:
-            parameter: param
             contains:
-              - 'this'
+              - 'param=value'
     actions:
       synthetic_response: 'match_query_contains'
 
 tests:
   - name: Test match query contains exact
     request:
-      url: 'https://test/query/contains?param=this'
+      url: 'https://test-query/query/contains?param=value'
     expect:
       status: 200
       body:
@@ -119,7 +112,23 @@ tests:
 
   - name: Test match query contains
     request:
-      url: 'https://test/query/contains?param=anything_and_this_yo?yeah=boi&oo=yo#yes'
+      url: 'https://test-query/query/contains?the=famous&param=value&in_the=middle'
+    expect:
+      status: 200
+      body:
+        - regex: 'match_query_contains'
+
+  - name: Test match query contains in beginning
+    request:
+      url: 'https://test-query/query/contains?param=value&in_the=beginning'
+    expect:
+      status: 200
+      body:
+        - regex: 'match_query_contains'
+
+  - name: Test match query contains in end
+    request:
+      url: 'https://test-query/query/contains?it_in=the_end_as&param=value'
     expect:
       status: 200
       body:
@@ -127,11 +136,9 @@ tests:
 
   - name: Test match query contains wrong
     request:
-      url: 'https://test/query/contains/?param=thiz&this=this'
-    expect:  # domain_default backend
-      status: 200
-      body:
-        - regex: 'name=1337'
+      url: 'https://test-query/query/contains?almost=param&value=but_not_quite'
+    expect:  # no configured backend
+      status: 500
 
 ---
 
@@ -140,23 +147,22 @@ schema_version: 1
 rules:
   - description: Test match query exact
     domains:
-      - test
+      - test-query
     matches:
       all:
         - paths:
             exact:
               - '/query/exact'
         - query:
-            parameter: param
             exact:
-              - 'this'
+              - 'param=value'
     actions:
       synthetic_response: 'match_query_exact'
 
 tests:
   - name: Test match query exact
     request:
-      url: 'https://test/query/exact?param=this'
+      url: 'https://test-query/query/exact?param=value'
     expect:
       status: 200
       body:
@@ -164,11 +170,9 @@ tests:
 
   - name: Test match query exact wrong
     request:
-      url: 'https://test/query/exact?param=this_is_not_exactly&this=this'
-    expect:  # domain_default backend
-      status: 200
-      body:
-        - regex: 'name=1337'
+      url: 'https://test-query/query/exact?param=value&not=exactly_right'
+    expect:  # no configured backend
+      status: 500
 
 ---
 
@@ -177,23 +181,22 @@ schema_version: 1
 rules:
   - description: Test match query regex
     domains:
-      - test
+      - test-query
     matches:
       all:
         - paths:
             exact:
               - '/query/regex'
         - query:
-            parameter: param
             regex:
-              - 'm[uU]st_have_(yeah|ooo)!{3,4}'
+              - 'param=m[uU]st_have_(yeah|ooo)!{3,4}'
     actions:
       synthetic_response: 'match_query_regex'
 
 tests:
   - name: Test match query regex
     request:
-      url: 'https://test/query/regex?param=mUst_have_ooo!!!'
+      url: 'https://test-query/query/regex?param=mUst_have_ooo!!!'
     expect:
       status: 200
       body:
@@ -201,44 +204,6 @@ tests:
 
   - name: Test match query regex wrong
     request:
-      url: 'https://test/query/regex/?param=must_have_yeah!!'
-    expect:  # domain_default backend
-      status: 200
-      body:
-        - regex: 'name=1337'
-
----
-
-schema_version: 1
-
-rules:
-  - description: Test match query param exist
-    domains:
-      - test
-    matches:
-      all:
-        - paths:
-            exact:
-              - '/query/exist'
-        - query:
-            parameter: param
-            exist: True
-    actions:
-      synthetic_response: 'match_query_exist_regex'
-
-tests:
-  - name: Test match query param exist
-    request:
-      url: 'https://test/query/exist?param=is_here'
-    expect:
-      status: 200
-      body:
-        - regex: 'match_query_exist_regex'
-
-  - name: Test match query param exist wrong
-    request:
-      url: 'https://test/query/exist?no=param'
-    expect:  # domain_default backend
-      status: 200
-      body:
-        - regex: 'name=1337'
+      url: 'https://test-query/query/regex?param=does&not_have_enough=yeah'
+    expect:  # no configured backend
+      status: 500

--- a/orm-rules-tests/rules-test/rules/test_path_regsub.yml
+++ b/orm-rules-tests/rules-test/rules/test_path_regsub.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'regsub default'

--- a/orm-rules-tests/rules-test/rules/test_redirect.yml
+++ b/orm-rules-tests/rules-test/rules/test_redirect.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Temporary redirect'
@@ -94,7 +94,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Dynamic redirect'

--- a/orm-rules-tests/rules-test/rules/test_req_path.yml
+++ b/orm-rules-tests/rules-test/rules/test_req_path.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test req_path replace from_exact to string'
@@ -30,7 +30,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test req_path replace from_regex to string'
@@ -60,7 +60,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test req_path replace from_regex to_regsub'
@@ -96,7 +96,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test req_path replace ignore_case true'
@@ -127,7 +127,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test req_path replace ignore_case false'

--- a/orm-rules-tests/rules-test/rules/test_req_path_prefix.yml
+++ b/orm-rules-tests/rules-test/rules/test_req_path_prefix.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Prefix path remove
@@ -29,7 +29,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Prefix path add
@@ -58,7 +58,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Prefix path remove and add

--- a/orm-rules-tests/rules-test/rules/test_string_mod.yml
+++ b/orm-rules-tests/rules-test/rules/test_string_mod.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test multiple string mod actions'

--- a/orm-rules-tests/rules-test/rules/test_trailing_slash.yml
+++ b/orm-rules-tests/rules-test/rules/test_trailing_slash.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test trailing_slash default (do nothing)
@@ -35,7 +35,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test trailing_slash add
@@ -88,7 +88,7 @@ tests:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test trailing_slash remove

--- a/orm-rules-tests/rules-test/rules/test_url_handling.yml
+++ b/orm-rules-tests/rules-test/rules/test_url_handling.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: 'Test url handling'

--- a/orm/parser.py
+++ b/orm/parser.py
@@ -255,16 +255,16 @@ def parse_document(doc):
     where 'rules' is a domain keyed dict containing lists of ORM rules.
     """
 
-    if doc.get("schema_version", 1) == 1:
-        return parse_document_v1(doc)
+    if doc.get("schema_version", 2) == 2:
+        return parse_document_v2(doc)
     else:
         raise ORMInternalParserException(
             "schema_version %s not supported" % doc["schema_version"]
         )
 
 
-def parse_document_v1(doc):
-    """ The document parser for schema version 1 """
+def parse_document_v2(doc):
+    """ The document parser for schema version 2 """
 
     if doc.get("schema_version"):
         del doc["schema_version"]

--- a/orm/schemas/common-2.json
+++ b/orm/schemas/common-2.json
@@ -1,0 +1,418 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "definitions": {
+    "schema_version": {
+      "type": "integer"
+    },
+    "http_header_field_name": {
+      "type": "string",
+      "format": "http-header-field-name"
+    },
+    "header": {
+      "type": "object",
+      "properties": {
+        "field": {"$ref": "#/definitions/http_header_field_name"},
+        "value": {
+          "type": "string",
+          "format": "http-header-field-value"
+        }
+      },
+      "required": ["field", "value"],
+      "additionalProperties": false
+    },
+    "header_mod": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "oneOf": [{
+          "properties": {
+            "set": {"$ref": "#/definitions/header"}
+          },
+          "additionalProperties": false
+        }, {
+          "properties": {
+            "add": {"$ref": "#/definitions/header"}
+          },
+          "additionalProperties": false
+        }, {
+          "properties": {
+            "remove": {
+              "$ref": "#/definitions/http_header_field_name"
+            }
+          },
+          "additionalProperties": false
+        }]
+      }
+    },
+    "string_replace": {
+      "type": "object",
+      "properties": {
+        "replace": {
+          "type": "object",
+          "properties": {
+            "ignore_case": {
+              "$ref": "#/definitions/match_ignore_case"
+            },
+            "from_regex": {
+              "type": "string",
+              "format": "orm_regex"
+            },
+            "from_exact": {
+              "type": "string",
+              "format": "uri-path"
+            },
+            "to": {
+              "type": "string",
+              "format": "uri-path"
+            },
+            "to_regsub": {
+              "type": "string",
+              "format": "orm_regsub"
+            }
+          },
+          "oneOf": [{
+            "required": ["from_regex"],
+            "oneOf": [{
+              "required": ["to_regsub"]
+            }, {
+              "required": ["to"]
+            }],
+            "not": {
+              "required": ["from_exact"]
+            }
+          }, {
+            "required": ["from_exact", "to"],
+            "not": {
+              "required": ["from_regex", "to_regsub"]
+            }
+          }],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "string_prefix": {
+      "type": "object",
+      "properties": {
+        "prefix": {
+          "type": "object",
+          "properties": {
+            "ignore_case": {
+              "$ref": "#/definitions/match_ignore_case"
+            },
+            "remove": {
+              "type": "string",
+              "format": "uri-path"
+            },
+            "add": {
+              "type": "string",
+              "format": "uri-path"
+            }
+          },
+          "anyOf": [{
+            "required": ["remove"]
+          }, {
+            "required": ["add"]
+          }],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "path_mod": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {"$ref": "#definitions/string_replace"},
+          {"$ref": "#definitions/string_prefix"}
+        ]
+      }
+    },
+    "redirect-type": {
+      "type": "string",
+      "enum": [
+        "permanent",
+        "temporary",
+        "permanent_allow_method_change",
+        "temporary_allow_method_change"
+      ]
+    },
+    "redirect": {
+      "type": "object",
+      "oneOf": [{
+        "properties": {
+          "type": {"$ref": "#definitions/redirect-type"},
+          "url": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": ["type", "url"],
+        "additionalProperties": false
+      }, {
+        "properties": {
+          "type": {"$ref": "#definitions/redirect-type"},
+          "scheme": {
+            "type": "string",
+            "enum": ["http", "https"]
+          },
+          "domain": {
+            "type": "string",
+            "format": "hostname"
+          },
+          "path": {"$ref": "#/definitions/path_mod"}
+        },
+        "allOf": [{
+          "required": ["type"]
+        }, {
+          "anyOf": [{
+            "required": ["scheme"]
+          }, {
+            "required": ["domain"]
+          }, {
+            "required": ["path"]
+          }]
+        }],
+        "additionalProperties": false
+      }]
+    },
+    "backend": {
+      "type": "object",
+      "oneOf": [{
+        "properties": {
+          "servers": {
+            "type": "array",
+            "items": {
+              "oneOf": [{
+                "type": "string",
+                "format": "origin"
+              }, {
+                "type": "object",
+                "properties": {
+                  "server": {
+                    "type": "string",
+                    "format": "origin"
+                  },
+                  "max_connections": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "max_queued_connections": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                },
+                "required": ["server"],
+                "additionalProperties": false
+              }]
+            }
+          }
+        },
+        "additionalProperties": false
+      }, {
+        "properties": {
+          "origin": {
+            "type": "string",
+            "format": "origin"
+          }
+        },
+        "additionalProperties": false
+      }]
+    },
+    "match_path_list": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri-path"
+      }
+    },
+    "match_query_list": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri-query"
+      }
+    },
+    "match_regex_list": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "orm_regex"
+      }
+    },
+    "match_negate": {
+      "type": "boolean"
+    },
+    "match_ignore_case": {
+      "type": "boolean"
+    },
+    "match_path": {
+      "type": "object",
+      "properties": {
+        "begins_with": {"$ref": "#/definitions/match_path_list"},
+        "ends_with": {"$ref": "#/definitions/match_path_list"},
+        "contains": {"$ref": "#/definitions/match_path_list"},
+        "exact": {"$ref": "#/definitions/match_path_list"},
+        "regex": {"$ref": "#/definitions/match_regex_list"},
+        "not": {"$ref": "#/definitions/match_negate"},
+        "ignore_case": {"$ref": "#/definitions/match_ignore_case"}
+      },
+      "anyOf": [
+        {"required": ["begins_with"]},
+        {"required": ["ends_with"]},
+        {"required": ["contains"]},
+        {"required": ["exact"]},
+        {"required": ["regex"]}
+      ],
+      "additionalProperties": false
+    },
+    "match_query": {
+      "type": "object",
+      "properties": {
+        "begins_with": {"$ref": "#/definitions/match_query_list"},
+        "ends_with": {"$ref": "#/definitions/match_query_list"},
+        "contains": {"$ref": "#/definitions/match_query_list"},
+        "exact": {"$ref": "#/definitions/match_query_list"},
+        "regex": {"$ref": "#/definitions/match_regex_list"},
+        "not": {"$ref": "#/definitions/match_negate"},
+        "ignore_case": {"$ref": "#/definitions/match_ignore_case"}
+      },
+      "anyOf": [
+        {"required": ["begins_with"]},
+        {"required": ["ends_with"]},
+        {"required": ["contains"]},
+        {"required": ["exact"]},
+        {"required": ["regex"]}
+      ],
+      "additionalProperties": false
+    },
+    "boolean_operator": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "oneOf": [{
+          "properties": {
+            "paths": {"$ref": "#/definitions/match_path"}
+          },
+          "additionalProperties": false
+        }, {
+          "properties": {
+            "query": {"$ref": "#/definitions/match_query"}
+          },
+          "additionalProperties": false
+        }]
+      }
+    },
+    "matches": {
+      "type": "object",
+      "properties": {
+        "all": {"$ref": "#/definitions/boolean_operator"},
+        "any": {"$ref": "#/definitions/boolean_operator"}
+      },
+      "additionalProperties": false
+    },
+    "trailing_slash": {
+      "type": "string",
+      "enum": ["add", "remove", "do_nothing"]
+    },
+    "https_redirection": {
+      "type": "boolean"
+    },
+    "actions": {
+      "type": "object",
+      "oneOf": [{
+        "properties": {
+          "redirect": {"$ref": "#/definitions/redirect"}
+        },
+        "additionalProperties": false
+      }, {
+        "properties": {
+          "trailing_slash": {"$ref": "#/definitions/trailing_slash"},
+          "backend": {"$ref": "#/definitions/backend"},
+          "req_path": {"$ref": "#/definitions/path_mod"},
+          "header_southbound": {"$ref": "#/definitions/header_mod"},
+          "header_northbound": {"$ref": "#/definitions/header_mod"},
+          "https_redirection": {"$ref": "#/definitions/https_redirection"}
+        },
+        "additionalProperties": false
+      }, {
+        "properties": {
+          "synthetic_response": {"type": "string"}
+        },
+        "additionalProperties": false
+      }]
+    },
+    "domains": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "hostname"
+      }
+    },
+    "rule_item": {
+      "type": "object",
+      "properties": {
+        "description": {"type": "string"},
+        "domains": {"$ref": "#/definitions/domains"},
+        "domain_default": {"type": "boolean"},
+        "matches": {"$ref": "#/definitions/matches"},
+        "actions": {"$ref": "#/definitions/actions"}
+      },
+      "required": ["domains", "description", "actions"],
+      "oneOf": [{
+        "required": ["matches"]
+      }, {
+        "required": ["domain_default"]
+      }],
+      "additionalProperties": false
+    },
+    "test_item": {
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "request": {"$ref": "#/definitions/test_request"},
+        "expect": {"$ref": "#/definitions/test_expect"}
+      },
+      "required": ["name", "request", "expect"],
+      "additionalProperties": false
+    },
+    "test_request": {
+      "type": "object",
+      "properties": {
+        "url": {"type": "string", "format": "uri"}
+      },
+      "required": ["url"],
+      "additionalProperties": false
+    },
+    "test_expect": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "regex": {"type": "string", "format": "orm_regex"}
+            },
+            "additionalProperties": false
+          }
+        },
+        "status": {"type": "integer"},
+        "headers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "field": {"$ref": "#/definitions/http_header_field_name"},
+              "regex": {"type": "string", "format": "orm_regex"}
+            },
+            "required": ["field", "regex"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/orm/schemas/rules-2.json
+++ b/orm/schemas/rules-2.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "object",
+  "properties": {
+    "schema_version": { "$ref": "common-2.json#/definitions/schema_version" },
+    "rules": {
+      "type": "array",
+      "items": {
+        "$ref": "common-2.json#/definitions/rule_item"
+      }
+    },
+    "tests": {
+      "type": "array",
+      "items": {
+        "$ref": "common-2.json#/definitions/test_item"
+      }
+    }
+  },
+  "required": ["schema_version", "rules"],
+  "additionalProperties": false
+}

--- a/orm/validator.py
+++ b/orm/validator.py
@@ -42,7 +42,7 @@ def validate_globals_file(globals_file):
 
 orm_schemas = {"rules": {}, "globals": {}}
 
-orm_schemas["rules"]["1"] = "rules-1.json"
+orm_schemas["rules"]["2"] = "rules-2.json"
 orm_schemas["globals"]["1"] = "globals-1.json"
 
 
@@ -53,9 +53,13 @@ def get_schema(yml_file, yml_doc, schema_type="rules"):
     schema_file = orm_schemas[schema_type].get(schema_version, None)
     if not schema_file:
         raise ORMSchemaException(
-            "ORM doc using unknown schema_version. "
+            "ORM doc using unsupported schema_version. "
             "Found '" + schema_version + "'. "
-            "Supports " + str(list(orm_schemas.keys())) + " (" + yml_file + ")"
+            "Supports "
+            + str(list(orm_schemas[schema_type].keys()))
+            + " ("
+            + yml_file
+            + ")"
         )
     json_file = open(os.path.join(schema_dir, schema_file))
     schema = json.load(json_file)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -104,7 +104,7 @@ class ParseRulesTest(unittest.TestCase):
         rule_bar.update(domains)
         tests = ['yeah', 'ooo']
         yml_doc = {
-            'schema_version': 1,
+            'schema_version': 2,
             'rules': [domains.copy(), domains.copy()],
             'tests': tests
         }
@@ -133,7 +133,7 @@ class ParseRulesTest(unittest.TestCase):
         rule_bar.update(both_domains)
         rule_baz.update(other_domain)
         yml_doc = {
-            'schema_version': 1,
+            'schema_version': 2,
             'rules': [rule_foo.copy(), rule_bar.copy(), rule_baz.copy()]
         }
         exp_parsed_doc = {

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -245,8 +245,9 @@ class ParseRulesTest(unittest.TestCase):
         docs = parser.parse_rules([self.defaults_file], defaults=defaults)
         self.assertEqual(docs, exp_docs)
 
-    def test_parse_match_paths(self):
-        # Test flattening
+    def test_parse_match_values(self):
+        # value_type path
+        ## Test flattening
         exp_tree = {
             'or': [
                 {'match': {
@@ -275,12 +276,15 @@ class ParseRulesTest(unittest.TestCase):
                     'source': 'path'}}
             ]
         }
-        tree = parser.parse_match_paths({
-            'exact': ['a', 'b'],
-            'regex': ['c', 'd'],
-        })
+        tree = parser.parse_match_values(
+            {
+                'exact': ['a', 'b'],
+                'regex': ['c', 'd'],
+            },
+            "path"
+        )
         self.assertEqual(tree, exp_tree)
-        # Test negation
+        ## Test negation
         exp_tree = {
             'not': {
                 'or': [
@@ -293,63 +297,45 @@ class ParseRulesTest(unittest.TestCase):
                 ]
             }
         }
-        tree = parser.parse_match_paths({
-            'exact': ['a'],
-            'not': True
-        })
+        tree = parser.parse_match_values(
+            {
+                'exact': ['a'],
+                'not': True
+            }, "path"
+        )
         self.assertEqual(tree, exp_tree)
 
-    def test_parse_match_query(self):
-        # Test flattening
+        # value_type query
+        ## Test flattening
         in_conf = {
-            'parameter': 'foo',
-            'exact': ['a', 'b'],
-            'regex': ['c', 'd']
+            'exact': ['foo=a', 'foo=b'],
+            'regex': ['foo=c', 'foo=d']
         }
         exp_tree = {
             'or': [
                 {'match': {
                     'function': 'exact',
-                    'input': {'parameter': 'foo',
-                              'value': 'a'},
+                    'input': {'value': 'foo=a'},
                     'source': 'query'}},
                 {'match': {
                     'function': 'exact',
-                    'input': {'parameter': 'foo',
-                              'value': 'b'},
+                    'input': {'value': 'foo=b'},
                     'source': 'query'}},
                 {'match': {
                     'function': 'regex',
-                    'input': {'parameter': 'foo',
-                              'value': 'c'},
+                    'input': {'value': 'foo=c'},
                     'source': 'query'}},
                 {'match': {
                     'function': 'regex',
-                    'input': {'parameter': 'foo',
-                              'value': 'd'},
+                    'input': {'value': 'foo=d'},
                     'source': 'query'}}
             ]
         }
-        tree = parser.parse_match_query(in_conf)
+        tree = parser.parse_match_values(in_conf, "query")
         self.assertEqual(tree, exp_tree)
-        # Test exist
+        ## Test negation
         in_conf = {
-            'parameter': 'foo',
-            'exist': True
-        }
-        exp_tree = {
-            'or': [
-                {'match': {
-                    'function': 'exist',
-                    'input': {'parameter': 'foo'},
-                    'source': 'query'}}
-            ]
-        }
-        tree = parser.parse_match_query(in_conf)
-        # Test negation
-        in_conf = {
-            'parameter': 'foo',
-            'exact': ['a'],
+            'exact': ['foo=a'],
             'not': True
         }
         exp_tree = {
@@ -357,13 +343,12 @@ class ParseRulesTest(unittest.TestCase):
                 'or': [
                     {'match': {
                         'function': 'exact',
-                        'input': {'parameter': 'foo',
-                                  'value': 'a'},
+                        'input': {'value': 'foo=a'},
                         'source': 'query'}}
                 ]
             }
         }
-        tree = parser.parse_match_query(in_conf)
+        tree = parser.parse_match_values(in_conf, "query")
         self.assertEqual(tree, exp_tree)
 
     def test_parse_match_binary_operator(self):

--- a/test/test_rendervarnish.py
+++ b/test/test_rendervarnish.py
@@ -78,27 +78,26 @@ class RenderVarnishTest(unittest.TestCase):
         self.assertNotEqual(name1, name2)
 
     def test_make_match_path(self):
-        inp = re.sub('\n|\r|\v|\f', '', string.printable)
         with self.assertRaises(ORMInternalRenderException):
             self.render.make_match_path('unsupported_match_function',
                                         {'value': 'derp'})
+        value = re.sub('\n|\r|\v|\f', '', string.printable)
+        inp = {'value': value}
         allowed_pattern = re.compile(r'^variable\.get\("path"\) ~ {?".*"}?$')
         for function in ['regex', 'exact', 'begins_with', 'ends_with',
                          'contains']:
-            match = self.render.make_match_path(function, {'value': inp})
+            match = self.render.make_match_path(function, inp)
             self.assertIsInstance(match, str)
             self.assertIsNotNone(re.search(allowed_pattern, match))
 
     def test_make_match_query(self):
-        param = re.sub('\n|\r|\v|\f', '', string.printable)
-        value = re.sub('\n|\r|\v|\f', '', string.printable)
-        inp = {'parameter': param,
-               'value': value}
         with self.assertRaises(ORMInternalRenderException):
             self.render.make_match_path('unsupported_match_function',
                                         {'value': 'derp'})
+        value = re.sub('\n|\r|\v|\f', '', string.printable)
+        inp = {'value': value}
         allowed_pattern = re.compile(r'^variable\.get\("query"\) ~ {?".*"}?$')
-        for function in ['exist', 'regex', 'exact', 'begins_with', 'ends_with',
+        for function in ['regex', 'exact', 'begins_with', 'ends_with',
                          'contains']:
             match = self.render.make_match_query(function, inp)
             self.assertIsInstance(match, str)

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -91,7 +91,7 @@ class ValidateRulesTest(unittest.TestCase):
                                                   schema_type)
                 self.assertIsInstance(orm_schema, dict)
 
-    def test_get_match_path_fsm(self):
+    def test_get_all_match_fsms(self):
         match_tree = {
             'and': [
                 {'or': [
@@ -116,16 +116,18 @@ class ValidateRulesTest(unittest.TestCase):
                 }}}
             ]
         }
-        fsm_obj = validator.get_match_path_fsm(match_tree)
-        self.assertIsInstance(fsm_obj, fsm)
+        fsm_obj = validator.get_all_match_fsms(match_tree)
+        self.assertIsInstance(fsm_obj, dict)
+        self.assertIsInstance(fsm_obj["path"], fsm)
         # Test match tree without any path matches
         match_tree = {
             'match': {'source': 'domain',
                       'function': 'exact',
                       'input': 'example.com'}
         }
-        fsm_obj = validator.get_match_path_fsm(match_tree)
-        self.assertIsInstance(fsm_obj, fsm)
+        fsm_obj = validator.get_all_match_fsms(match_tree)
+        self.assertIsInstance(fsm_obj, dict)
+        self.assertIsInstance(fsm_obj["path"], fsm)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/testdata/parser/invalid_rule.failyml
+++ b/test/testdata/parser/invalid_rule.failyml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Sport RSS

--- a/test/testdata/parser/rule.yml
+++ b/test/testdata/parser/rule.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Sport RSS

--- a/test/testdata/parser/rule2.yml
+++ b/test/testdata/parser/rule2.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test 1
@@ -18,7 +18,7 @@ rules:
 
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Test 2

--- a/test/testdata/ruletests/rule-with-tests.yml
+++ b/test/testdata/ruletests/rule-with-tests.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Dummy rule

--- a/test/testdata/validator/domain_default_false.yml
+++ b/test/testdata/validator/domain_default_false.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Domain default false

--- a/test/testdata/validator/ignore_case.yml
+++ b/test/testdata/validator/ignore_case.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: This rule should collide with

--- a/test/testdata/validator/invalid_collision.yml
+++ b/test/testdata/validator/invalid_collision.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: The first rule

--- a/test/testdata/validator/invalid_schema.yml
+++ b/test/testdata/validator/invalid_schema.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Sport RSS

--- a/test/testdata/validator/multiple_domain_default.yml
+++ b/test/testdata/validator/multiple_domain_default.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: One domain default

--- a/test/testdata/validator/rule.yml
+++ b/test/testdata/validator/rule.yml
@@ -1,6 +1,6 @@
 ---
 
-schema_version: 1
+schema_version: 2
 
 rules:
   - description: Sport RSS


### PR DESCRIPTION
Closes https://github.com/SVT/orm/issues/12

- Change schema to remove parameter from query matches (i.e. to work like path matches)
- Bump schema version (to deprecate old query match format)
- Change parser, validator and varnish render to use new query match format
- Collision check query matches in validator
- Add unit tests
- Add deployment tests
- Update docs

These changes require an ORM major version bump. Added the PR to [milestone v2](https://github.com/SVT/orm/milestone/1)