### PR TITLE
Handle prefix removal when entire path is removed

### DIFF
--- a/orm-rules-tests/rules-test/default-globals/rules/test_req_path_prefix.yml
+++ b/orm-rules-tests/rules-test/default-globals/rules/test_req_path_prefix.yml
@@ -32,6 +32,35 @@ tests:
 schema_version: 1
 
 rules:
+  - description: Prefix path remove entire path
+    domains:
+      - test
+    matches:
+      all:
+        - paths:
+            begins_with:
+              - '/req_path/prefix/remove_all'
+    actions:
+      req_path:
+        - prefix:
+            remove: /req_path/prefix/remove_all
+      backend:
+        origin: 'http://127.0.0.1:7357'
+
+tests:
+  - name: Test prefix path remove entire path
+    request:
+      url: 'https://test/req_path/prefix/remove_all'
+    expect:
+      status: 200
+      body:
+        - regex: 'path=/'
+
+---
+
+schema_version: 1
+
+rules:
   - description: Prefix path add
     domains:
       - test

--- a/orm/templates/varnish.vcl.j2
+++ b/orm/templates/varnish.vcl.j2
@@ -168,9 +168,9 @@ sub use_backend {
 
 sub reconstruct_requrl {
   if (variable.get("path") != "") {
-  set req.url = variable.get("path");
+    set req.url = variable.get("path");
   } else {
-  set req.url = "/";
+    set req.url = "/";
   }
   if (variable.get("query") != "") {
     set req.url = req.url + "?" + variable.get("query");

--- a/orm/templates/varnish.vcl.j2
+++ b/orm/templates/varnish.vcl.j2
@@ -167,7 +167,11 @@ sub use_backend {
 {% if uses_sub_use_backend %}
 
 sub reconstruct_requrl {
+  if (variable.get("path") != "") {
   set req.url = variable.get("path");
+  } else {
+  set req.url = "/";
+  }
   if (variable.get("query") != "") {
     set req.url = req.url + "?" + variable.get("query");
   }


### PR DESCRIPTION
The req_path action allows for removing the entire matched path,
which could lead to an empty "path" variable in Varnish. This
did not render the config invalid but caused a 503 to be thrown
when the rule was triggered. The config template now includes a
check for an empty path variable and handles the case correctly.

Resolves #37 