### PR TITLE
Keep newlines in synthetic responses (based on v1 branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Keep newlines in synthetic responses
+
 ## [1.2.0] - 2020-03-06
 
 ### Added

--- a/orm/rendervarnish.py
+++ b/orm/rendervarnish.py
@@ -18,8 +18,9 @@ def vcl_escape_regex(regex):
     return regex
 
 
-def vcl_safe_string(string):
-    string = string.replace("\n", "")
+def vcl_safe_string(string, strip_newline=True):
+    if strip_newline:
+        string = string.replace("\n", "")
     split = string.split(r'"}')
     if len(split) == 1:
         if r'"' in split[0]:
@@ -268,7 +269,12 @@ def make_redirect_action(config_in, config_out, rule_id, indent_depth=0):
 
 
 def make_synth_resp_action(config_in, config_out, rule_id, indent_depth=0):
-    synth = indent(3) + "synthetic(" + vcl_safe_string(config_in) + ");"
+    synth = (
+        indent(3)
+        + "synthetic("
+        + vcl_safe_string(config_in, strip_newline=False)
+        + ");"
+    )
     synth_clause = make_action_if_clause([synth], rule_id, indent_depth=2)
     config_out["synth"] = synth_clause
     config_out["sb"] = [indent(indent_depth) + 'return (synth(750, ""));']

--- a/test/test_rendervarnish.py
+++ b/test/test_rendervarnish.py
@@ -65,6 +65,13 @@ class RenderVarnishTest(unittest.TestCase):
         exp_str = '"ab"'
         nice_newline_str = rendervarnish.vcl_safe_string(newline_str)
         self.assertEqual(nice_newline_str, exp_str)
+        # newline_body_str contains '\n' which should be kept in the string
+        newline_body_str = "<html>\n<body>\nHello\n</body>\n</html>"
+        exp_str = '"<html>\n<body>\nHello\n</body>\n</html>"'
+        nice_with_newlines_str = rendervarnish.vcl_safe_string(newline_body_str,
+                                                               strip_newline=False)
+        self.assertEqual(nice_with_newlines_str, exp_str)
+
 
     def test_get_unique_vcl_name(self):
         namespace = 'ns'


### PR DESCRIPTION
This is just a copy of https://github.com/svt/orm/pull/54 but based on the v1 branch that seems to run parallel to master.

(I'm creating this to see if the travis tests succeed)